### PR TITLE
create a run manager to simplify running tests/make them a one liner and implement reading api key from an environment variable

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -4,3 +4,6 @@ README.md
 
 # Add `run_tests` function
 src/scorecard/client.py
+src/scorecard/run_context.py
+src/scorecard/api_key.py
+tests/test_run_manager.py

--- a/poetry.lock
+++ b/poetry.lock
@@ -29,7 +29,6 @@ files = [
 exceptiongroup = {version = "*", markers = "python_version < \"3.11\""}
 idna = ">=2.8"
 sniffio = ">=1.1"
-typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
 doc = ["Sphinx", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx-rtd-theme (>=1.2.2)", "sphinxcontrib-jquery"]
@@ -82,9 +81,6 @@ files = [
     {file = "h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761"},
     {file = "h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d"},
 ]
-
-[package.dependencies]
-typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "httpcore"
@@ -142,26 +138,6 @@ files = [
 ]
 
 [[package]]
-name = "importlib-metadata"
-version = "6.7.0"
-description = "Read metadata from Python packages"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "importlib_metadata-6.7.0-py3-none-any.whl", hash = "sha256:cb52082e659e97afc5dac71e79de97d8681de3aa07ff18578330904a9d18e5b5"},
-    {file = "importlib_metadata-6.7.0.tar.gz", hash = "sha256:1aaf550d4f73e5d6783e7acb77aec43d49da8017410afae93822cc9cca98c4d4"},
-]
-
-[package.dependencies]
-typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
-zipp = ">=0.5"
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-perf = ["ipython"]
-testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)", "pytest-ruff"]
-
-[[package]]
 name = "iniconfig"
 version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
@@ -207,7 +183,6 @@ files = [
 [package.dependencies]
 mypy-extensions = ">=0.4.3"
 tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-typed-ast = {version = ">=1.4.0,<2", markers = "python_version < \"3.8\""}
 typing-extensions = ">=3.10"
 
 [package.extras]
@@ -247,9 +222,6 @@ files = [
     {file = "pluggy-1.2.0-py3-none-any.whl", hash = "sha256:c2fd55a7d7a3863cba1a013e4e2414658b1d07b6bc57b3919e0c63c9abb99849"},
     {file = "pluggy-1.2.0.tar.gz", hash = "sha256:d12f0c4b579b15f5e054301bb226ee85eeeba08ffec228092f8defbaa3a4c4b3"},
 ]
-
-[package.dependencies]
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [package.extras]
 dev = ["pre-commit", "tox"]
@@ -393,6 +365,25 @@ files = [
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
+name = "pydantic-settings"
+version = "2.2.1"
+description = "Settings management using Pydantic"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pydantic_settings-2.2.1-py3-none-any.whl", hash = "sha256:0235391d26db4d2190cb9b31051c4b46882d28a51533f97440867f012d4da091"},
+    {file = "pydantic_settings-2.2.1.tar.gz", hash = "sha256:00b9f6a5e95553590434c0fa01ead0b216c3e10bc54ae02e37f359948643c5ed"},
+]
+
+[package.dependencies]
+pydantic = ">=2.3.0"
+python-dotenv = ">=0.21.0"
+
+[package.extras]
+toml = ["tomli (>=2.0.1)"]
+yaml = ["pyyaml (>=6.0.1)"]
+
+[[package]]
 name = "pytest"
 version = "7.4.4"
 description = "pytest: simple powerful testing with Python"
@@ -406,7 +397,6 @@ files = [
 [package.dependencies]
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
@@ -414,6 +404,20 @@ tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+
+[[package]]
+name = "python-dotenv"
+version = "1.0.1"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca"},
+    {file = "python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a"},
+]
+
+[package.extras]
+cli = ["click (>=5.0)"]
 
 [[package]]
 name = "sniffio"
@@ -438,56 +442,6 @@ files = [
 ]
 
 [[package]]
-name = "typed-ast"
-version = "1.5.5"
-description = "a fork of Python 2 and 3 ast modules with type comment support"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "typed_ast-1.5.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4bc1efe0ce3ffb74784e06460f01a223ac1f6ab31c6bc0376a21184bf5aabe3b"},
-    {file = "typed_ast-1.5.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5f7a8c46a8b333f71abd61d7ab9255440d4a588f34a21f126bbfc95f6049e686"},
-    {file = "typed_ast-1.5.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:597fc66b4162f959ee6a96b978c0435bd63791e31e4f410622d19f1686d5e769"},
-    {file = "typed_ast-1.5.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d41b7a686ce653e06c2609075d397ebd5b969d821b9797d029fccd71fdec8e04"},
-    {file = "typed_ast-1.5.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:5fe83a9a44c4ce67c796a1b466c270c1272e176603d5e06f6afbc101a572859d"},
-    {file = "typed_ast-1.5.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:d5c0c112a74c0e5db2c75882a0adf3133adedcdbfd8cf7c9d6ed77365ab90a1d"},
-    {file = "typed_ast-1.5.5-cp310-cp310-win_amd64.whl", hash = "sha256:e1a976ed4cc2d71bb073e1b2a250892a6e968ff02aa14c1f40eba4f365ffec02"},
-    {file = "typed_ast-1.5.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c631da9710271cb67b08bd3f3813b7af7f4c69c319b75475436fcab8c3d21bee"},
-    {file = "typed_ast-1.5.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b445c2abfecab89a932b20bd8261488d574591173d07827c1eda32c457358b18"},
-    {file = "typed_ast-1.5.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cc95ffaaab2be3b25eb938779e43f513e0e538a84dd14a5d844b8f2932593d88"},
-    {file = "typed_ast-1.5.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:61443214d9b4c660dcf4b5307f15c12cb30bdfe9588ce6158f4a005baeb167b2"},
-    {file = "typed_ast-1.5.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:6eb936d107e4d474940469e8ec5b380c9b329b5f08b78282d46baeebd3692dc9"},
-    {file = "typed_ast-1.5.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e48bf27022897577d8479eaed64701ecaf0467182448bd95759883300ca818c8"},
-    {file = "typed_ast-1.5.5-cp311-cp311-win_amd64.whl", hash = "sha256:83509f9324011c9a39faaef0922c6f720f9623afe3fe220b6d0b15638247206b"},
-    {file = "typed_ast-1.5.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:44f214394fc1af23ca6d4e9e744804d890045d1643dd7e8229951e0ef39429b5"},
-    {file = "typed_ast-1.5.5-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:118c1ce46ce58fda78503eae14b7664163aa735b620b64b5b725453696f2a35c"},
-    {file = "typed_ast-1.5.5-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:be4919b808efa61101456e87f2d4c75b228f4e52618621c77f1ddcaae15904fa"},
-    {file = "typed_ast-1.5.5-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:fc2b8c4e1bc5cd96c1a823a885e6b158f8451cf6f5530e1829390b4d27d0807f"},
-    {file = "typed_ast-1.5.5-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:16f7313e0a08c7de57f2998c85e2a69a642e97cb32f87eb65fbfe88381a5e44d"},
-    {file = "typed_ast-1.5.5-cp36-cp36m-win_amd64.whl", hash = "sha256:2b946ef8c04f77230489f75b4b5a4a6f24c078be4aed241cfabe9cbf4156e7e5"},
-    {file = "typed_ast-1.5.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:2188bc33d85951ea4ddad55d2b35598b2709d122c11c75cffd529fbc9965508e"},
-    {file = "typed_ast-1.5.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0635900d16ae133cab3b26c607586131269f88266954eb04ec31535c9a12ef1e"},
-    {file = "typed_ast-1.5.5-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:57bfc3cf35a0f2fdf0a88a3044aafaec1d2f24d8ae8cd87c4f58d615fb5b6311"},
-    {file = "typed_ast-1.5.5-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:fe58ef6a764de7b4b36edfc8592641f56e69b7163bba9f9c8089838ee596bfb2"},
-    {file = "typed_ast-1.5.5-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:d09d930c2d1d621f717bb217bf1fe2584616febb5138d9b3e8cdd26506c3f6d4"},
-    {file = "typed_ast-1.5.5-cp37-cp37m-win_amd64.whl", hash = "sha256:d40c10326893ecab8a80a53039164a224984339b2c32a6baf55ecbd5b1df6431"},
-    {file = "typed_ast-1.5.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:fd946abf3c31fb50eee07451a6aedbfff912fcd13cf357363f5b4e834cc5e71a"},
-    {file = "typed_ast-1.5.5-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:ed4a1a42df8a3dfb6b40c3d2de109e935949f2f66b19703eafade03173f8f437"},
-    {file = "typed_ast-1.5.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:045f9930a1550d9352464e5149710d56a2aed23a2ffe78946478f7b5416f1ede"},
-    {file = "typed_ast-1.5.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:381eed9c95484ceef5ced626355fdc0765ab51d8553fec08661dce654a935db4"},
-    {file = "typed_ast-1.5.5-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:bfd39a41c0ef6f31684daff53befddae608f9daf6957140228a08e51f312d7e6"},
-    {file = "typed_ast-1.5.5-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:8c524eb3024edcc04e288db9541fe1f438f82d281e591c548903d5b77ad1ddd4"},
-    {file = "typed_ast-1.5.5-cp38-cp38-win_amd64.whl", hash = "sha256:7f58fabdde8dcbe764cef5e1a7fcb440f2463c1bbbec1cf2a86ca7bc1f95184b"},
-    {file = "typed_ast-1.5.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:042eb665ff6bf020dd2243307d11ed626306b82812aba21836096d229fdc6a10"},
-    {file = "typed_ast-1.5.5-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:622e4a006472b05cf6ef7f9f2636edc51bda670b7bbffa18d26b255269d3d814"},
-    {file = "typed_ast-1.5.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1efebbbf4604ad1283e963e8915daa240cb4bf5067053cf2f0baadc4d4fb51b8"},
-    {file = "typed_ast-1.5.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f0aefdd66f1784c58f65b502b6cf8b121544680456d1cebbd300c2c813899274"},
-    {file = "typed_ast-1.5.5-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:48074261a842acf825af1968cd912f6f21357316080ebaca5f19abbb11690c8a"},
-    {file = "typed_ast-1.5.5-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:429ae404f69dc94b9361bb62291885894b7c6fb4640d561179548c849f8492ba"},
-    {file = "typed_ast-1.5.5-cp39-cp39-win_amd64.whl", hash = "sha256:335f22ccb244da2b5c296e6f96b06ee9bed46526db0de38d2f0e5a6597b81155"},
-    {file = "typed_ast-1.5.5.tar.gz", hash = "sha256:94282f7a354f36ef5dbce0ef3467ebf6a258e370ab33d5b40c249fa996e590dd"},
-]
-
-[[package]]
 name = "typing-extensions"
 version = "4.7.1"
 description = "Backported and Experimental Type Hints for Python 3.7+"
@@ -498,22 +452,7 @@ files = [
     {file = "typing_extensions-4.7.1.tar.gz", hash = "sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2"},
 ]
 
-[[package]]
-name = "zipp"
-version = "3.15.0"
-description = "Backport of pathlib-compatible object wrapper for zip files"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "zipp-3.15.0-py3-none-any.whl", hash = "sha256:48904fc76a60e542af151aded95726c1a5c34ed43ab4134b597665c86d7ad556"},
-    {file = "zipp-3.15.0.tar.gz", hash = "sha256:112929ad649da941c23de50f356a2b5570c954b65150642bccdd66bf194d224b"},
-]
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
-
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.7"
-content-hash = "4ac84aae6b05a415337279868d39fe7ce44104dffcd6b159af9e12dcea350ba1"
+python-versions = "^3.8"
+content-hash = "ae434c4e3ff70b4cd42eb5ed7bb3ae42917159bac989931d29dcfdce133a0cea"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,11 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
 httpx = ">=0.21.2"
 pydantic = ">= 1.9.2, < 2.5.0"
+python-dotenv = "^1.0.1"
+pydantic-settings = "^2.2.1"
 
 [tool.poetry.dev-dependencies]
 mypy = "0.971"

--- a/src/scorecard/api_key.py
+++ b/src/scorecard/api_key.py
@@ -1,0 +1,22 @@
+from functools import lru_cache
+from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import Field, field_validator
+
+class ApiKeyProvider(BaseSettings):
+    api_key: str = Field(default="", alias="SCORECARD_API_KEY")
+    model_config = SettingsConfigDict(env_prefix="SCORECARD_", env_file=".env")
+
+    @field_validator('api_key')
+    def check_api_key(cls, v):
+        if not v:
+            raise ValueError("SCORECARD_API_KEY must be provided in the environment. Try setting it in your dotenv file.")
+        return v
+
+
+@lru_cache
+def get_api_key() -> str:
+    return ApiKeyProvider().api_key
+
+
+if __name__ == "__main__":
+    print(get_api_key())

--- a/src/scorecard/run_manager.py
+++ b/src/scorecard/run_manager.py
@@ -1,4 +1,4 @@
-from typing import Callable, Tuple
+from typing import Callable, Tuple, Optional
 from scorecard.client import Scorecard
 from scorecard.types import RunStatus, TestCase, Run
 from scorecard.api_key import get_api_key
@@ -10,7 +10,7 @@ class TestOutput(BaseModel):
     response: str
 
 class RunManager:
-    def __init__(self, test_set: int, scoring_config_id: int, runnable: Callable[[TestCase], TestOutput], client: Scorecard | None = None):
+    def __init__(self, test_set: int, scoring_config_id: int, runnable: Callable[[TestCase], TestOutput], client: Optional[Scorecard] = None):
         self.test_set = test_set
         self.scoring_config_id = scoring_config_id
         self.runnable = runnable

--- a/src/scorecard/run_manager.py
+++ b/src/scorecard/run_manager.py
@@ -1,6 +1,6 @@
-from typing import Callable, Tuple, Optional
+from typing import Callable, Tuple, Optional, Union
 from scorecard.client import Scorecard
-from scorecard.types import RunStatus, TestCase, Run
+from scorecard.types import RunStatus, TestCase, Run, Testset
 from scorecard.api_key import get_api_key
 from pydantic import BaseModel
 
@@ -10,7 +10,14 @@ class TestOutput(BaseModel):
     response: str
 
 class RunManager:
-    def __init__(self, test_set: int, scoring_config_id: int, runnable: Callable[[TestCase], TestOutput], client: Optional[Scorecard] = None):
+    def __init__(self, test_set: Union[int, Testset], scoring_config_id: int, runnable: Callable[[TestCase], TestOutput], client: Optional[Scorecard] = None):
+
+        if isinstance(test_set, Testset):
+            if test_set.id is None:
+                raise ValueError("Testset has not been synced with scorecard.")
+            else:
+                test_set = test_set.id
+
         self.test_set = test_set
         self.scoring_config_id = scoring_config_id
         self.runnable = runnable

--- a/src/scorecard/run_manager.py
+++ b/src/scorecard/run_manager.py
@@ -1,0 +1,47 @@
+from typing import Callable, Tuple
+from scorecard.client import Scorecard
+from scorecard.types import RunStatus, TestCase, Run
+from scorecard.api_key import get_api_key
+from pydantic import BaseModel
+
+
+class TestOutput(BaseModel):
+    context: str
+    response: str
+
+class RunManager:
+    def __init__(self, test_set: int, scoring_config_id: int, runnable: Callable[[TestCase], TestOutput], client: Scorecard | None = None):
+        self.test_set = test_set
+        self.scoring_config_id = scoring_config_id
+        self.runnable = runnable
+        if client is None:
+            self.client = Scorecard(api_key=get_api_key())
+        else:
+            self.client = client
+
+    def run(self) -> Tuple[Run, str]:
+        run = self.client.run.create(testset_id=self.test_set, scoring_config_id=self.scoring_config_id)
+        if run.id is None:
+            raise ValueError("Failed to create run")
+
+        run = self.client.run.update_status(run_id=run.id, status=RunStatus.RUNNING_EXECUTION)
+
+        if run.id is None: 
+            raise ValueError("Failed to update run status to RUNNING_EXECUTION")
+
+        try:
+            print("here")
+            for testcase in self.client.testset.get_testcases(testset_id=self.test_set).results:
+                test_record = self.runnable(testcase)
+                self.client.testrecord.create(run_id=run.id,
+                                              testset_id=self.test_set,
+                                              testcase_id=testcase.id,
+                                              user_query=testcase.user_query,
+                                              context=test_record.context,
+                                              response=test_record.response)
+        except Exception as e:
+            print(e)
+        finally:
+            self.client.run.update_status(run_id=run.id, status=RunStatus.AWAITING_SCORING)
+
+            return run , f"https://app.getscorecard.ai/view-records/{run.id}"

--- a/tests/test_run_manager.py
+++ b/tests/test_run_manager.py
@@ -1,0 +1,79 @@
+from datetime import datetime
+import pytest
+from unittest.mock import MagicMock, patch
+from scorecard.run_manager import RunManager, TestOutput
+from scorecard.types import RunStatus, TestCase, Run
+from dotenv import load_dotenv, set_key
+from os import remove
+
+@pytest.fixture
+def run_manager_setup_teardown():
+    fake_env_file = '.env.test'
+    test_set = 123
+    scoring_config_id = 456
+    runnable = MagicMock(return_value={'context': 'test_context', 'response': 'test_response'})
+    client = MagicMock()
+
+    fake_env = {
+        'SCORECARD_API_KEY': 'test_api_key',
+    }
+    with open(fake_env_file, 'w') as file:
+        for key, value in fake_env.items():
+            set_key(fake_env_file, key, value)
+    load_dotenv(dotenv_path=fake_env_file)
+
+    run_manager = RunManager(test_set=test_set, scoring_config_id=scoring_config_id, runnable=runnable, client=client)
+
+    yield run_manager, client, test_set, scoring_config_id, runnable  
+
+    remove(fake_env_file)
+
+# Test function using the fixture
+@patch('scorecard.run_manager.Scorecard')
+def test_run_manager(mock_scorecard, run_manager_setup_teardown):
+    run_manager, client, test_set, scoring_config_id, runnable = run_manager_setup_teardown
+
+    mock_run = Run(id=1, 
+               scoring_config_id=scoring_config_id, 
+               testset_id=test_set, 
+               status=RunStatus.RUNNING_EXECUTION, 
+               created_at=datetime.now(),
+               updated_at=None,
+               scoring_start_time=None, 
+               scoring_end_time=None,
+               execution_start_time=datetime.now(),
+               execution_end_time=None,
+               limit_testcases=None,
+               source=None,
+               model_params=None,
+               notes=None,
+               prompt_template=None)
+
+    client.run.create.return_value = mock_run
+    client.run.update_status.return_value = mock_run.copy(update={'status': RunStatus.AWAITING_SCORING})
+    test_cases_response = MagicMock()
+    test_cases_response.results = [
+        TestCase(id=1, testset_id=test_set, user_query='query1', created_at=None, context="context 1", ideal=None, custom_inputs=None, custom_labels=None),
+        TestCase(id=2, testset_id=test_set, user_query='query2', created_at=None, context="context 2", ideal=None, custom_inputs=None, custom_labels=None)
+    ]
+    client.testset.get_testcases.return_value = test_cases_response
+
+    # Mock the runnable to simulate execution
+    runnable.side_effect = lambda testcase: TestOutput(context=testcase.context, response=f'response to {testcase.user_query}')
+
+    # Execute the method under test
+    run, url = run_manager.run()
+
+    # Assertions
+    client.run.create.assert_called_once_with(testset_id=test_set, scoring_config_id=scoring_config_id)
+    client.run.update_status.assert_called_with(run_id=mock_run.id, status=RunStatus.AWAITING_SCORING)
+
+    client.testset.get_testcases.assert_called_once_with(testset_id=test_set)
+    assert client.testset.get_testcases.return_value.results == test_cases_response.results
+    assert len(client.testset.get_testcases.return_value.results) == 2
+    # Ensure test records are created for each test case
+    assert client.testrecord.create.call_count == 2
+
+    assert run != mock_run
+    assert run.status == RunStatus.AWAITING_SCORING
+    assert url == f"https://app.getscorecard.ai/view-records/{run.id}"


### PR DESCRIPTION
Running a test should now look like this.

- Add your SCORECARD_API_KEY to your .env file.

``` python
from scorecard.run_manager import RunManager, TestOutput

def test(test_case: TestCase) -> TestOutput:

    # Over here you would make an actual LLM call, but keeping it brief.
    response_text = f"{test_case.user_query} - processed"
    context_text = test_case.user_query
    return TestOutput(context=context_text, response=response_text)

if __name__ == "__main__":
    run = RunManager(test_set=141, scoring_config_id=164, runnable=test).run()
    print(run)

```