### PR TITLE
Hoist mypy config out of pyproject.toml

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -2,6 +2,7 @@
 
 README.md
 LICENSE
+mypy.ini
 src/scorecard/client.py
 src/scorecard/telemetry.py
 .github/workflows/ci.yml

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,3 @@
+[mypy]
+plugins = pydantic.mypy
+ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,6 @@ testpaths = [ "tests" ]
 asyncio_mode = "auto"
 
 [tool.mypy]
-ignore_missing_imports = true
 plugins = ["pydantic.mypy"]
 
 


### PR DESCRIPTION
This enables mypy to be resilient to manifest file regeneration.