### PR TITLE
feat: Add multi-turn simulation helper

### DIFF
--- a/src/scorecard_ai/lib/__init__.py
+++ b/src/scorecard_ai/lib/__init__.py
@@ -2,3 +2,7 @@ from ._helpers import (
     run_and_evaluate as run_and_evaluate,
     async_run_and_evaluate as async_run_and_evaluate,
 )
+from ._multi_turn_simulation import (
+    ChatMessage as ChatMessage,
+    multi_turn_simulation as multi_turn_simulation,
+)

--- a/src/scorecard_ai/lib/_multi_turn_simulation.py
+++ b/src/scorecard_ai/lib/_multi_turn_simulation.py
@@ -1,0 +1,174 @@
+"""
+Multi-turn simulation.
+"""
+
+from __future__ import annotations
+
+from typing import List, Literal, Callable, TypedDict
+from collections.abc import Iterable
+
+import httpx
+
+from scorecard_ai import Scorecard
+from scorecard_ai._types import NOT_GIVEN, NotGiven
+from scorecard_ai.lib._helpers import RunResponse, _get_run_url
+
+
+class ChatMessage(TypedDict):
+    """
+    A message in a chat. Follows the ChatML format.
+    """
+
+    role: Literal["user", "assistant", "system", "tool"]
+    content: str
+
+
+def run_simulation(
+    client: Scorecard,
+    *,
+    initial_messages: List[ChatMessage],
+    system: Callable[[List[ChatMessage]], Iterable[str | ChatMessage]],
+    start_with_system: bool | NotGiven = NOT_GIVEN,
+    max_turns: int,
+    sim_agent_version_id: str,
+    testcase_id: str,
+) -> List[ChatMessage]:
+    """
+    Runs a single simulation for a Scorecard Testcase.
+
+    Args:
+        client: The Scorecard client.
+
+        initial_messages: A list of ChatML messages that seed the conversation
+            before the simulation begins.
+
+        system: A callable that, given the conversation so far, yields one or
+            more assistant/tool messages to append when it is the system's turn.
+
+        start_with_system: If provided, forces the conversation to start with
+            the system's turn (`True`) or with the simulated agent (`False`).
+            When omitted, the function infers the starting turn based on the
+            role of the last message in `initial_messages`.
+
+        max_turns: The number of turns (system plus agent) to simulate.
+
+        sim_agent_version_id: The ID of the SystemVersion to invoke for the
+            simulated agent.
+
+        testcase_id: The ID of the Testcase being simulated.
+
+    Returns:
+        All ChatML messages exchanged during the simulation, in order.
+    """
+    messages = list(initial_messages)
+    is_system_turn: bool
+    if start_with_system is not NOT_GIVEN:
+        is_system_turn = bool(start_with_system)
+    else:
+        is_system_turn = len(messages) > 0 and messages[-1]["role"] == "user"
+
+    for _ in range(max_turns):
+        if is_system_turn:
+            # Call the system function
+            system_responses = list(system(messages))
+            for system_response in system_responses:
+                if isinstance(system_response, str):
+                    messages.append(
+                        ChatMessage(role="assistant", content=system_response)
+                    )
+                else:
+                    messages.append(system_response)
+        else:
+            # Call the simulated agent
+            response = client.post(
+                f"/agents/{sim_agent_version_id}/simulate",
+                cast_to=httpx.Response,
+                body={
+                    "testcaseId": testcase_id,
+                    "messages": messages,
+                },
+            )
+            response.raise_for_status()
+            messages.extend(response.json()["messages"])
+        is_system_turn = not is_system_turn
+    return messages
+
+
+def multi_turn_simulation(
+    client: Scorecard,
+    *,
+    project_id: str,
+    metric_ids: List[str],
+    testset_id: str,
+    sim_agent_id: str,
+    system: Callable[[List[ChatMessage]], Iterable[str | ChatMessage]],
+    initial_messages: List[ChatMessage] | NotGiven = NOT_GIVEN,
+    start_with_system: bool | NotGiven = NOT_GIVEN,
+    max_turns: int = 5,
+) -> RunResponse:
+    """
+    Simulates a multi-turn conversation for each Testcase in a Testset and
+    records the results in a Scorecard Run.
+
+    Args:
+        client: The Scorecard client.
+
+        project_id: The ID of the Project that the Run will belong to.
+
+        metric_ids: The IDs of the Metrics that should be used to evaluate the Run.
+
+        testset_id: The ID of the Testset whose Testcases will be executed.
+
+        sim_agent_id: The ID of the System that represents the simulated agent.
+            Its production SystemVersion will be invoked for each simulation.
+
+        system: A callable that, given the conversation so far, yields one or
+            more assistant/tool messages to append when it is the system's turn.
+
+        initial_messages: Optional ChatML messages that seed every conversation
+            before simulation begins.
+
+        start_with_system: If provided, forces each conversation to start with
+            the system's turn (`True`) or with the simulated agent (`False`).
+            When omitted, the function infers the starting turn from
+            `initial_messages`.
+
+        max_turns: The maximum number of turns (system plus agent) to simulate
+            for each Testcase.
+
+    Returns:
+        A `RunResponse` containing the ID and UI URL of the created Run.
+    """
+
+    system_version_id = client.systems.get(system_id=sim_agent_id).production_version.id
+
+    run = client.runs.create(
+        project_id=project_id,
+        testset_id=testset_id,
+        metric_ids=metric_ids,
+        system_version_id=system_version_id,
+    )
+
+    # Run each Testcase sequentially
+    for testcase in client.testcases.list(testset_id):
+        messages = run_simulation(
+            client,
+            initial_messages=initial_messages or [],
+            system=system,
+            start_with_system=start_with_system,
+            max_turns=max_turns,
+            sim_agent_version_id=system_version_id,
+            testcase_id=testcase.id,
+        )
+        client.records.create(
+            run_id=run.id,
+            testcase_id=testcase.id,
+            inputs=testcase.inputs,
+            expected=testcase.expected,
+            outputs={"messages": messages},
+        )
+
+    return RunResponse(
+        id=run.id,
+        url=_get_run_url(client, project_id, run.id),
+    )


### PR DESCRIPTION
Example usage:

Define your system:

```py
from openai import OpenAI

def customer_service_system(chat_history: List[ChatMessage]) -> dict:
    system_prompt = "You are a customer support agent. Help the customer and remain polite. Try to figure out what is wrong with the product first, then accept a return only if it is appropriate and matches reasonable return guidelines."
    client = OpenAI()
    response = client.chat.completions.create(
        model="gpt-4.1",
        messages=[ChatMessage(role="system", content=system_prompt)] + chat_history
    )
    return [response.choices[0].message.content]
```

Then run the simulation:

```py
from scorecard_ai import Scorecard
from scorecard_ai.lib import multi_turn_simulation

scorecard = Scorecard()

conversation = multi_turn_simulation(
    client=scorecard,
    project_id="150",
    system=lambda chat_history: customer_service_system(chat_history),
    metric_ids=[],
    testset_id="48673",
    sim_agent_id="b07db73f-3707-4919-bbcb-26989e92e9cd",
    max_turns=10,
)
```